### PR TITLE
Добавил метаданные для pdf.

### DIFF
--- a/dm.sty
+++ b/dm.sty
@@ -18,6 +18,20 @@
 \def\tunemarkup#1#2{\@ifundefined{tune@markup@#1}{}{#2}}
 \def\tunemarkuptwo#1#2#3{\@ifundefined{tune@markup@#1}{#3}{#2}}
 
+\AtBeginDocument{%
+\hypersetup{%
+  pdftitle={Демократический манифест (Эмери Ривз)},%
+  pdfauthor={Сергей Прокопов <sergeiprokopov@gmail.com>},%
+  pdfcreator={Bibles.org.uk Типографская среда на базе TeX Live 2023},%
+  pdfsubject={демократия,США},%
+  pdfkeywords={демократия,США,урантийские документы},%
+  pdflang={Russian},%
+  pdfcreationdate={D:20230123111100Z},%
+  pdfmoddate={D:\pdfdate-00'00'}%
+}%
+}
+
+
 \renewcommand{\thechapter}{\Roman{chapter}}
 \titleformat{\chapter}[display]
   {\Huge\rmfamily\centering}  


### PR DESCRIPTION
Добавил конфигурацию pdf метаданных. Это имеет следующие премущества:

1. Не открывая сам pdf файл можно узнать о нём информацию, включая дату последнего обновления.
2. Отличать дату создания книги (т.е. начала работы над переводом) с датой генерации данного pdf файла.

Вот как это выглядит:

```
$ pdfinfo dm.pdf
Title:           Демократический манифест (Эмери Ривз)
Subject:         демократия,США
Keywords:        демократия,США,урантийские документы
Author:          Сергей Прокопов <sergeiprokopov@gmail.com>
Creator:         Bibles.org.uk Типографская среда на базе TeX Live 2023
Producer:        xdvipdfmx (20220710)
CreationDate:    Mon Jan 23 11:11:00 2023 GMT
ModDate:         Mon Nov 13 10:23:00 2023 GMT
Custom Metadata: no
Metadata Stream: no
Tagged:          no
UserProperties:  no
Suspects:        no
Form:            none
JavaScript:      no
Pages:           166
Encrypted:       no
Page size:       382.68 x 612.28 pts
Page rot:        0
File size:       561516 bytes
Optimized:       no
PDF version:     1.5
```

Сам физический файл `pdf/dm.pdf` я не стал обновлять, ибо считаю, что вообще в github репозитории не стоит хранить pdf файл.